### PR TITLE
Replace ESynth with nUSD and fuzz tests

### DIFF
--- a/src/PegStabilityModule.sol
+++ b/src/PegStabilityModule.sol
@@ -1,0 +1,158 @@
+pragma solidity ^0.8.0;
+
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "openzeppelin-contracts/utils/math/Math.sol";
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+import {nUSD} from "./nUSD.sol";
+
+/// @title PegStabilityModule
+/// @notice Simplified PegStabilityModule with configurable fees and fee receiver.
+contract PegStabilityModule is Ownable {
+    using SafeERC20 for IERC20;
+    using Math for uint256;
+
+    uint256 public constant BPS_SCALE = 100_00;
+    uint256 public constant PRICE_SCALE = 1e18;
+
+    nUSD public immutable synth;
+    IERC20 public immutable underlying;
+    uint256 public immutable CONVERSION_PRICE;
+
+    address public feeRecipient;
+    uint256 public toUnderlyingFeeBPS;
+    uint256 public toSynthFeeBPS;
+
+    error E_ZeroAddress();
+    error E_FeeExceedsBPS();
+    error E_ZeroConversionPrice();
+
+    constructor(
+        address _synth,
+        address _underlying,
+        address _feeRecipient,
+        uint256 _toUnderlyingFeeBPS,
+        uint256 _toSynthFeeBPS,
+        uint256 _conversionPrice
+    ) Ownable(msg.sender) {
+        if (_synth == address(0) || _underlying == address(0) || _feeRecipient == address(0)) {
+            revert E_ZeroAddress();
+        }
+        if (_toUnderlyingFeeBPS >= BPS_SCALE || _toSynthFeeBPS >= BPS_SCALE) {
+            revert E_FeeExceedsBPS();
+        }
+        if (_conversionPrice == 0) {
+            revert E_ZeroConversionPrice();
+        }
+
+        synth = nUSD(_synth);
+        underlying = IERC20(_underlying);
+        feeRecipient = _feeRecipient;
+        toUnderlyingFeeBPS = _toUnderlyingFeeBPS;
+        toSynthFeeBPS = _toSynthFeeBPS;
+        CONVERSION_PRICE = _conversionPrice;
+    }
+
+    function setFees(uint256 _toUnderlyingFeeBPS, uint256 _toSynthFeeBPS) external onlyOwner {
+        if (_toUnderlyingFeeBPS >= BPS_SCALE || _toSynthFeeBPS >= BPS_SCALE) {
+            revert E_FeeExceedsBPS();
+        }
+        toUnderlyingFeeBPS = _toUnderlyingFeeBPS;
+        toSynthFeeBPS = _toSynthFeeBPS;
+    }
+
+    function setFeeRecipient(address _feeRecipient) external onlyOwner {
+        if (_feeRecipient == address(0)) revert E_ZeroAddress();
+        feeRecipient = _feeRecipient;
+    }
+
+    function swapToUnderlyingGivenIn(uint256 amountIn, address receiver) external returns (uint256) {
+        uint256 amountOut = quoteToUnderlyingGivenIn(amountIn);
+        if (amountIn == 0 || amountOut == 0) {
+            return 0;
+        }
+
+        uint256 totalUnderlying = Math.mulDiv(amountIn, CONVERSION_PRICE, PRICE_SCALE);
+        uint256 fee = totalUnderlying - amountOut;
+
+        synth.burn(_msgSender(), amountIn);
+        underlying.safeTransfer(receiver, amountOut);
+        if (fee > 0) underlying.safeTransfer(feeRecipient, fee);
+
+        return amountOut;
+    }
+
+    function swapToUnderlyingGivenOut(uint256 amountOut, address receiver) external returns (uint256) {
+        uint256 amountIn = quoteToUnderlyingGivenOut(amountOut);
+        if (amountIn == 0 || amountOut == 0) {
+            return 0;
+        }
+
+        uint256 totalUnderlying = Math.mulDiv(amountIn, CONVERSION_PRICE, PRICE_SCALE);
+        uint256 fee = totalUnderlying - amountOut;
+
+        synth.burn(_msgSender(), amountIn);
+        underlying.safeTransfer(receiver, amountOut);
+        if (fee > 0) underlying.safeTransfer(feeRecipient, fee);
+
+        return amountIn;
+    }
+
+    function swapToSynthGivenIn(uint256 amountIn, address receiver) external returns (uint256) {
+        uint256 amountOut = quoteToSynthGivenIn(amountIn);
+        if (amountIn == 0 || amountOut == 0) {
+            return 0;
+        }
+
+        underlying.safeTransferFrom(_msgSender(), address(this), amountIn);
+
+        uint256 mintedUnderlying = Math.mulDiv(amountOut, CONVERSION_PRICE, PRICE_SCALE);
+        uint256 fee = amountIn - mintedUnderlying;
+        if (fee > 0) underlying.safeTransfer(feeRecipient, fee);
+
+        synth.mint(receiver, amountOut);
+
+        return amountOut;
+    }
+
+    function swapToSynthGivenOut(uint256 amountOut, address receiver) external returns (uint256) {
+        uint256 amountIn = quoteToSynthGivenOut(amountOut);
+        if (amountIn == 0 || amountOut == 0) {
+            return 0;
+        }
+
+        underlying.safeTransferFrom(_msgSender(), address(this), amountIn);
+
+        uint256 mintedUnderlying = Math.mulDiv(amountOut, CONVERSION_PRICE, PRICE_SCALE);
+        uint256 fee = amountIn - mintedUnderlying;
+        if (fee > 0) underlying.safeTransfer(feeRecipient, fee);
+
+        synth.mint(receiver, amountOut);
+
+        return amountIn;
+    }
+
+    function quoteToUnderlyingGivenIn(uint256 amountIn) public view returns (uint256) {
+        return amountIn.mulDiv(
+            (BPS_SCALE - toUnderlyingFeeBPS) * CONVERSION_PRICE, BPS_SCALE * PRICE_SCALE, Math.Rounding.Floor
+        );
+    }
+
+    function quoteToUnderlyingGivenOut(uint256 amountOut) public view returns (uint256) {
+        return amountOut.mulDiv(
+            BPS_SCALE * PRICE_SCALE, (BPS_SCALE - toUnderlyingFeeBPS) * CONVERSION_PRICE, Math.Rounding.Ceil
+        );
+    }
+
+    function quoteToSynthGivenIn(uint256 amountIn) public view returns (uint256) {
+        return amountIn.mulDiv(
+            (BPS_SCALE - toSynthFeeBPS) * PRICE_SCALE, BPS_SCALE * CONVERSION_PRICE, Math.Rounding.Floor
+        );
+    }
+
+    function quoteToSynthGivenOut(uint256 amountOut) public view returns (uint256) {
+        return amountOut.mulDiv(
+            BPS_SCALE * CONVERSION_PRICE, (BPS_SCALE - toSynthFeeBPS) * PRICE_SCALE, Math.Rounding.Ceil
+        );
+    }
+}

--- a/test/PegStabilityModule.t.sol
+++ b/test/PegStabilityModule.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {PegStabilityModule} from "../src/PegStabilityModule.sol";
+import {nUSD} from "../src/nUSD.sol";
+import {TestERC20} from "../lib/euler-vault-kit/test/mocks/TestERC20.sol";
+
+contract PegStabilityModuleTest is Test {
+    uint256 constant CONVERSION_PRICE = 1e18;
+    uint256 constant TO_UNDERLYING_FEE = 100; // 1%
+    uint256 constant TO_SYNTH_FEE = 50; // 0.5%
+
+    nUSD synth;
+    TestERC20 underlying;
+    PegStabilityModule psm;
+
+    address owner = makeAddr("owner");
+    address user = makeAddr("user");
+    address receiver = makeAddr("receiver");
+    address feeRecipient = makeAddr("feeRecipient");
+
+    function setUp() public {
+        vm.prank(owner);
+        synth = new nUSD(address(1), "Synth", "SYN");
+
+        underlying = new TestERC20("Underlying", "UND", 18, false);
+
+        vm.prank(owner);
+        psm = new PegStabilityModule(
+            address(synth), address(underlying), feeRecipient, TO_UNDERLYING_FEE, TO_SYNTH_FEE, CONVERSION_PRICE
+        );
+
+        underlying.mint(address(psm), 1000 ether);
+        underlying.mint(user, 1000 ether);
+
+        vm.startPrank(owner);
+        synth.setCapacity(address(psm), type(uint128).max);
+        synth.setCapacity(owner, type(uint128).max);
+        synth.mint(user, 1000 ether);
+        vm.stopPrank();
+
+        vm.prank(user);
+        synth.approve(address(psm), type(uint256).max);
+        vm.prank(user);
+        underlying.approve(address(psm), type(uint256).max);
+    }
+
+    function testFuzz_swapToUnderlyingFunnelFee(uint96 amountIn) public {
+        amountIn = uint96(bound(amountIn, 1e18, synth.balanceOf(user)));
+        uint256 expectedOut = psm.quoteToUnderlyingGivenIn(amountIn);
+        uint256 totalUnderlying = (amountIn * CONVERSION_PRICE) / psm.PRICE_SCALE();
+        uint256 fee = totalUnderlying - expectedOut;
+
+        vm.prank(user);
+        psm.swapToUnderlyingGivenIn(amountIn, receiver);
+
+        assertEq(underlying.balanceOf(receiver), expectedOut);
+        assertEq(underlying.balanceOf(feeRecipient), fee);
+    }
+
+    function testFuzz_swapToSynthFunnelFee(uint96 amountIn) public {
+        amountIn = uint96(bound(amountIn, 1e18, underlying.balanceOf(user)));
+        uint256 expectedOut = psm.quoteToSynthGivenIn(amountIn);
+        uint256 mintedUnderlying = (expectedOut * CONVERSION_PRICE) / psm.PRICE_SCALE();
+        uint256 fee = amountIn - mintedUnderlying; // 1:1 price
+
+        vm.prank(user);
+        psm.swapToSynthGivenIn(amountIn, receiver);
+
+        assertEq(synth.balanceOf(receiver), expectedOut);
+        assertEq(underlying.balanceOf(feeRecipient), fee);
+    }
+
+    function testFuzz_setFees(uint256 uFee, uint256 sFee) public {
+        uFee = bound(uFee, 0, psm.BPS_SCALE() - 1);
+        sFee = bound(sFee, 0, psm.BPS_SCALE() - 1);
+        vm.prank(owner);
+        psm.setFees(uFee, sFee);
+
+        assertEq(psm.toUnderlyingFeeBPS(), uFee);
+        assertEq(psm.toSynthFeeBPS(), sFee);
+    }
+}

--- a/test/nUSDGeneral.t.sol
+++ b/test/nUSDGeneral.t.sol
@@ -10,7 +10,6 @@ import {MockWrongEVC} from "../lib/euler-vault-kit/test/mocks/MockWrongEVC.sol";
 import {EthereumVaultConnector} from "ethereum-vault-connector/EthereumVaultConnector.sol";
 import {IEVault} from "euler-vault-kit/EVault/IEVault.sol";
 import {Errors} from "euler-vault-kit/EVault/shared/Errors.sol";
-import {ESynth} from "euler-vault-kit/Synths/ESynth.sol";
 
 import {nUSD} from "../src/nUSD.sol";
 import {IRMStabilityFee} from "../src/IRMStabilityFee.sol";
@@ -81,7 +80,7 @@ contract nUSDGeneralTest is EVaultTestBase {
         amount = uint128(bound(amount, 0, MAX_ALLOWED));
         vm.assume(capacity < amount);
         nusd.setCapacity(address(this), capacity);
-        vm.expectRevert(ESynth.E_CapacityReached.selector);
+        vm.expectRevert(nUSD.E_CapacityReached.selector);
         nusd.mint(user1, amount);
     }
 
@@ -149,7 +148,7 @@ contract nUSDGeneralTest is EVaultTestBase {
         uint256 amount = 100e18;
         nusd.setCapacity(address(this), MAX_ALLOWED);
         nusd.mint(address(nusd), amount);
-        vm.expectRevert(ESynth.E_NotEVCCompatible.selector);
+        vm.expectRevert(nUSD.E_NotEVCCompatible.selector);
         nusd.allocate(address(wrongEVC), amount);
     }
 


### PR DESCRIPTION
## Summary
- update PegStabilityModule to depend on nUSD
- use nUSD in module tests and convert them to property-based tests
- update general nUSD tests for new error references

## Testing
- `forge build`
- `forge test -vvv`


------
https://chatgpt.com/codex/tasks/task_e_688bc8ed6bd88327b371324ade3cebee